### PR TITLE
Feature/labview

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,47 @@ Start the InfluxDB service:
 docker compose up -d influxdb
 ```
 
+Check that influxdb is running with: 
+
+```
+docker compose ps 
+```
+
+If the influxdb container keeps restarting, something is going wrong. 
+Check the logs: 
+
+```
+docker compose logs -f influxdb
+```
+
+If you see: 
+
+```
+stack-influxdb-1  | Error: config name "default" already exists
+```
+
+Then remove the default section from `influxdb/config/influx-configs`: 
+
+```
+[default]
+  url = "http://localhost:8086"
+  token = "LQTfSPzx9pwBMWmOzdhPWiM_vQb7aaO-Qy5uKhEpICs0SuXL4ie40Rv-S2DzkErBevBRk64wsEZ0S_uheZpjxQ=="
+  org = "cms-tedd"
+  active = true
+```
+
+And try again from the beginning of this section
+
 Extract the generated token to later connect to influxdb from telegraf
 and from grafana: 
 
-```bash
+```
 docker exec stack-influxdb-1 influx auth list --user dbuser 
 ```
 
 Create a file named `my.env` with this content (make sure to use your own token): 
 
-```shell  
+```  
 TRACKER_DCS_INFLUXDB_TOKEN=<influxdb_token>
 ```
 

--- a/doc/grafana.md
+++ b/doc/grafana.md
@@ -164,8 +164,10 @@ To do this, click the share button, and export as JSON.
 which will allow you to select the datasource on the other system.
 
 To import a dashboard, use the Dashboards menu. 
-During the import, you need to update the data source uid so that it matches
-the data source on your system (click update, it will be done automatically).
+
+After the import, you won't see any data plotted in the dashboard panels. 
+You need to open the dashboard panels and reselect InfluxDB as a source. 
+Then wait a bit, and you should see data appear. 
 
 You may commit your dashboards in [../grafana/dashboards](../grafana/dashboards).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,8 @@ services:
       - mosquitto
 
   web_server:
-    image: ghcr.io/cms-tedd-ip2i/tracker_dcs_web:0.1.0
+    # image: ghcr.io/cms-tedd-ip2i/tracker_dcs_web:0.1.0
+    image: webserver_local
     restart: always
     #stdin_open: true
     #tty: true
@@ -67,13 +68,14 @@ services:
     # TODO: setup authentication
     environment:
       - MQTT_HOST=mosquitto
+      - MQTT_PORT=1883
     ports:
       - "8001:8000"
     expose:
       - "8001"
     command: ["uvicorn", "tracker_dcs_web.web_server.app:app", "--host", "0.0.0.0"]
     volumes:
-      - web_server:/code
+      - web_server:/app/files
     depends_on:
       - mosquitto
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,8 +80,8 @@ services:
       - mosquitto
 
   labview:
-    # image: ghcr.io/cms-tedd-ip2i/tracker_dcs_web:0.1.0
-    image: webserver_local
+    image: ghcr.io/cms-tedd-ip2i/tracker_dcs_web:0.2.0
+    # image: webserver_local
     restart: always
     command: ["dummy_labview", "http://web_server:8000", "labview/mapping.txt", "labview/header.txt", "labview/measures.txt"]
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,12 +72,21 @@ services:
     ports:
       - "8001:8000"
     expose:
-      - "8001"
+      - "8000"
     command: ["uvicorn", "tracker_dcs_web.web_server.app:app", "--host", "0.0.0.0"]
     volumes:
       - web_server:/app/files
     depends_on:
       - mosquitto
+
+  labview:
+    # image: ghcr.io/cms-tedd-ip2i/tracker_dcs_web:0.1.0
+    image: webserver_local
+    restart: always
+    command: ["dummy_labview", "http://web_server:8000", "labview/mapping.txt", "labview/header.txt", "labview/measures.txt"]
+    depends_on:
+      - web_server
+
     
   low_voltage:
     image: ghcr.io/cms-tedd-ip2i/low_voltage:0.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
 
   web_server:
     image: ghcr.io/cms-tedd-ip2i/tracker_dcs_web:0.2.0
-    image: webserver_local
+    # image: webserver_local
     restart: always
     #stdin_open: true
     #tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - mosquitto
 
   web_server:
-    # image: ghcr.io/cms-tedd-ip2i/tracker_dcs_web:0.1.0
+    image: ghcr.io/cms-tedd-ip2i/tracker_dcs_web:0.2.0
     image: webserver_local
     restart: always
     #stdin_open: true

--- a/grafana/dashboards/initial_test_dashboard-1689755203309_labview.json
+++ b/grafana/dashboards/initial_test_dashboard-1689755203309_labview.json
@@ -1,0 +1,259 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_INFLUXDB",
+      "label": "InfluxDB",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.2"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "All temperatures",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "from(bucket: \"my-bucket\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"labview\")\n  |> filter(fn: (r) => r._field =~ /.*_T.*/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Temperatures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "query": "from(bucket: \"my-bucket\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"sensor_1\")\n  |> filter(fn: (r) => r._field =~ /meas.*/)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Sensor 1",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "initial_test_dashboard",
+  "uid": "LouhvboVk",
+  "version": 3,
+  "weekStart": ""
+}

--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -64,8 +64,8 @@
   servers = ["tcp://mosquitto:1883"]
 ## Topics that will be subscribed to.
    topics = [
-    "/web_server",
+    "/labview",
   ]
-  name_override = "web_server"
+  name_override = "labview"
   tag_keys = ["number"]
   data_format = "json"


### PR DESCRIPTION
Now that the new version of the web server is ready, we include it to the stack

* fix docker compose for web_server : 
  * expose correct port
  * map volume to /app/files so that we keep the state for the current labview data 
* add dummy labview service that sends dummy data to the web server
* telegraf configuration for web server 
* add grafana dashboard for labview data  sent by the web server. The web server writes to the topic `/labview` 
* documentation 